### PR TITLE
Updated package.json windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "os": [
     "darwin",
     "linux",
-    "win64"
+    "win32"
   ],
   "engines": {
     "node": ">=8.11.4"


### PR DESCRIPTION
Changed os requirement "win64" to "win32", as the win64 doesnt exists as result. Windows returns "win32" no matter x64 or x86.

**Please describe the changes this PR makes and why it should be merged:**

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
